### PR TITLE
Support for QApplication.

### DIFF
--- a/src/native/QmlNet/Hosting/CoreHost.h
+++ b/src/native/QmlNet/Hosting/CoreHost.h
@@ -3,6 +3,7 @@
 
 #include <QSharedPointer>
 #include <Hosting/coreclrhost.h>
+#include <QApplication>
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
 
@@ -35,10 +36,12 @@ public:
         Failed
     };
     typedef int (*runCallback)(QGuiApplication* app, QQmlApplicationEngine* engine);
+    typedef int (*runCallback)(QApplication* app, QQmlApplicationEngine* engine);
 
     static QList<QString> getPotientialDotnetRoots();
     static HostFxrContext findHostFxr();
     static int run(QGuiApplication& app, QQmlApplicationEngine& engine, runCallback runCallback, RunContext runContext);
+    static int run(QApplication& app, QQmlApplicationEngine& engine, runCallback runCallback, RunContext runContext);
 };
 
 #endif

--- a/src/native/QmlNet/QmlNet/qml/QApplication.cpp
+++ b/src/native/QmlNet/QmlNet/qml/QApplication.cpp
@@ -1,0 +1,79 @@
+#include <QmlNet/qml/QApplication.h>
+#include <QmlNet/qml/NetVariantList.h>
+#include <QApplication>
+
+GuiThreadContextTriggerCallback::GuiThreadContextTriggerCallback() :
+    callback(nullptr) {
+}
+
+void GuiThreadContextTriggerCallback::trigger() {
+    if (callback) {
+       callback();
+    }
+}
+
+extern "C" {
+
+Q_DECL_EXPORT QApplicationContainer* qapplication_create(NetVariantListContainer* argsContainer, QApplication* existingApp) {
+    QApplicationContainer* result = new QApplicationContainer();
+
+    if (existingApp != nullptr) {
+        result->ownsApp = false;
+        result->app = existingApp;
+    } else {
+        result->ownsApp = true;
+        // Build our args
+        if(argsContainer != nullptr) {
+            QSharedPointer<NetVariantList> args = argsContainer->list;
+            for(int x = 0; x < args->count(); x++) {
+                QByteArray arg = args->get(x)->getString().toLatin1();
+                result->args.append(arg);
+                char* cstr = nullptr;
+                cstr = new char [arg.size()+1];
+                strcpy(cstr, arg.data());
+                result->argsPointer.push_back(cstr);
+            }
+            result->argCount = result->args.size();
+        } else {
+            result->argCount = 0;
+        }
+        result->app = new QApplication(result->argCount, &result->argsPointer[0], 0);
+    }
+
+    result->callback = QSharedPointer<GuiThreadContextTriggerCallback>(new GuiThreadContextTriggerCallback());
+
+    return result;
+}
+
+Q_DECL_EXPORT void qapplication_destroy(QApplicationContainer* container) {
+    for (auto i : container->argsPointer) {
+        delete i;
+    }
+    container->callback.clear();
+    if(container->ownsApp) {
+        delete container->app;
+    }
+    delete container;
+}
+
+Q_DECL_EXPORT int qapplication_exec(QApplicationContainer* container) {
+    return container->app->exec();
+}
+
+Q_DECL_EXPORT void qapplication_addTriggerCallback(QApplicationContainer* container, guiThreadTriggerCb callback) {
+    container->callback->callback = callback;
+}
+
+Q_DECL_EXPORT void qapplication_requestTrigger(QApplicationContainer* container) {
+    QMetaObject::invokeMethod(container->callback.data(), "trigger", Qt::QueuedConnection);
+}
+
+Q_DECL_EXPORT void qapplication_exit(QApplicationContainer* container, int returnCode) {
+    container->app->exit(returnCode);
+}
+
+Q_DECL_EXPORT QApplication* qapplication_internalPointer(QApplicationContainer* container) {
+    return container->app;
+}
+
+}

--- a/src/native/QmlNet/QmlNet/qml/QApplication.h
+++ b/src/native/QmlNet/QmlNet/qml/QApplication.h
@@ -21,7 +21,7 @@ struct QApplicationContainer {
     QList<QString> args;
     std::vector<char*> argsPointer;
     QApplication* app;
-    bool ownsGuiApp;
+    bool ownsApp;
     QSharedPointer<GuiThreadContextTriggerCallback> callback;
 };
 

--- a/src/native/QmlNet/QmlNet/qml/QApplication.h
+++ b/src/native/QmlNet/QmlNet/qml/QApplication.h
@@ -1,0 +1,28 @@
+#ifndef NET_QAPPLICATION_H
+#define NET_QAPPLICATION_H
+
+#include <QmlNet.h>
+#include <QApplication>
+#include <QSharedPointer>
+
+typedef void (*guiThreadTriggerCb)();
+
+class GuiThreadContextTriggerCallback : public QObject {
+    Q_OBJECT
+public:
+    GuiThreadContextTriggerCallback();
+    guiThreadTriggerCb callback;
+public slots:
+    void trigger();
+};
+
+struct QApplicationContainer {
+    int argCount;
+    QList<QString> args;
+    std::vector<char*> argsPointer;
+    QApplication* app;
+    bool ownsGuiApp;
+    QSharedPointer<GuiThreadContextTriggerCallback> callback;
+};
+
+#endif // NET_QAPPLICATION_H

--- a/src/native/QmlNet/QmlNet/qml/qml.pri
+++ b/src/native/QmlNet/QmlNet/qml/qml.pri
@@ -1,4 +1,5 @@
 HEADERS += \
+    $$PWD/QApplication.h \
     $$PWD/QGuiApplication.h \
     $$PWD/QQmlApplicationEngine.h \
     $$PWD/NetVariant.h \
@@ -17,6 +18,7 @@ HEADERS += \
     $$PWD/QtWebEngine.h
 
 SOURCES += \
+    $$PWD/QApplication.cpp \
     $$PWD/QGuiApplication.cpp \
     $$PWD/QQmlApplicationEngine.cpp \
     $$PWD/NetVariant.cpp \

--- a/src/net/Qml.Net/Internal/Interop.cs
+++ b/src/net/Qml.Net/Internal/Interop.cs
@@ -138,6 +138,7 @@ namespace Qml.Net.Internal
             INetMethodInfoInterop,
             INetPropertyInfoInterop,
             INetTypeManagerInterop,
+            IQApplicationInterop,
             IQGuiApplicationInterop,
             IQQmlApplicationEngine,
             INetVariantInterop,
@@ -165,7 +166,9 @@ namespace Qml.Net.Internal
         public static INetPropertyInfoInterop NetPropertyInfo { get; }
         
         public static INetTypeManagerInterop NetTypeManager { get; }
-        
+
+        public static IQApplicationInterop QApplication { get; }
+
         public static IQGuiApplicationInterop QGuiApplication { get; }
         
         public static IQQmlApplicationEngine QQmlApplicationEngine { get; }

--- a/src/net/Qml.Net/Internal/Interop.cs
+++ b/src/net/Qml.Net/Internal/Interop.cs
@@ -87,6 +87,7 @@ namespace Qml.Net.Internal
             NetMethodInfo = interop;
             NetPropertyInfo = interop;
             NetTypeManager = interop;
+            QApplication = interop;
             QGuiApplication = interop;
             QQmlApplicationEngine = interop;
             NetVariant = interop;

--- a/src/net/Qml.Net/QApplication.cs
+++ b/src/net/Qml.Net/QApplication.cs
@@ -1,0 +1,164 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading;
+using AdvancedDLSupport;
+using Qml.Net.Internal;
+using Qml.Net.Internal.Qml;
+
+namespace Qml.Net
+{
+    public sealed class QApplication : BaseDisposable
+    {
+        readonly Queue<Action> _actionQueue = new Queue<Action>();
+        GCHandle _triggerHandle;
+        readonly SynchronizationContext _oldSynchronizationContext;
+
+        public QApplication()
+            :this(null)
+        {
+            
+        }
+        
+        public QApplication(string[] args)
+            :base(Create(args?.ToList()))
+        {
+            TriggerDelegate triggerDelegate = Trigger;
+            _triggerHandle = GCHandle.Alloc(triggerDelegate);
+            
+            Interop.QApplication.AddTriggerCallback(Handle, Marshal.GetFunctionPointerForDelegate(triggerDelegate));
+            
+            _oldSynchronizationContext = SynchronizationContext.Current;
+            SynchronizationContext.SetSynchronizationContext(new QtSynchronizationContext(this));
+        }
+
+        internal QApplication(IntPtr existingApp)
+            :base(CreateFromExisting(existingApp))
+        {
+            TriggerDelegate triggerDelegate = Trigger;
+            _triggerHandle = GCHandle.Alloc(triggerDelegate);
+            
+            Interop.QApplication.AddTriggerCallback(Handle, Marshal.GetFunctionPointerForDelegate(triggerDelegate));
+            
+            _oldSynchronizationContext = SynchronizationContext.Current;
+            SynchronizationContext.SetSynchronizationContext(new QtSynchronizationContext(this));
+        }
+
+        public int Exec()
+        {
+            return Interop.QApplication.Exec(Handle);
+        }
+
+        public void Dispatch(Action action)
+        {
+            lock (_actionQueue)
+            {
+                _actionQueue.Enqueue(action);
+            }
+            RequestTrigger();
+        }
+
+        public void Exit(int returnCode = 0)
+        {
+            Interop.QApplication.Exit(Handle, returnCode);
+        }
+
+        public void Quit()
+        {
+            Exit();
+        }
+
+        private void RequestTrigger()
+        {
+            Interop.QApplication.RequestTrigger(Handle);
+        }
+
+        internal IntPtr InternalPointer => Interop.QApplication.InternalPointer(Handle);
+
+        private void Trigger()
+        {
+            Action action;
+            lock (_actionQueue)
+            {
+                action = _actionQueue.Dequeue();
+            }
+            action?.Invoke();
+        }
+        
+        protected override void DisposeUnmanaged(IntPtr ptr)
+        {
+            SynchronizationContext.SetSynchronizationContext(_oldSynchronizationContext);
+            Interop.QApplication.Destroy(ptr);
+            _triggerHandle.Free();
+        }
+
+        private static IntPtr CreateFromExisting(IntPtr app)
+        {
+            return Interop.QApplication.Create(IntPtr.Zero, app);
+        }
+
+        private static IntPtr Create(List<string> args)
+        {
+            if (args == null)
+            {
+                args = new List<string>();
+            }
+            
+            // By default, the argv[0] should be the process name.
+            // .NET doesn't pass that name, but Qt should get it
+            // since it does in a normal Qt environment.
+            args.Insert(0, System.Diagnostics.Process.GetCurrentProcess().ProcessName);
+
+            using (var strings = new NetVariantList())
+            {
+                foreach (var arg in args)
+                {
+                    using (var variant = new NetVariant())
+                    {
+                        variant.String = arg;
+                        strings.Add(variant);
+                    }
+                }
+                return Interop.QApplication.Create(strings.Handle, IntPtr.Zero);
+            }
+        }
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate void TriggerDelegate();
+        
+        private class QtSynchronizationContext : SynchronizationContext
+        {
+            readonly QApplication _app;
+
+            public QtSynchronizationContext(QApplication app)
+            {
+                _app = app;
+            }
+
+            public override void Post(SendOrPostCallback d, object state)
+            {
+                _app.Dispatch(() => d.Invoke(state));
+            }
+        }
+    }
+    
+    internal interface IQApplicationInterop
+    {
+        [NativeSymbol(Entrypoint = "qapplication_create")]
+        IntPtr Create(IntPtr args, IntPtr existingApp);
+        [NativeSymbol(Entrypoint = "qapplication_destroy")]
+        void Destroy(IntPtr app);
+
+        [NativeSymbol(Entrypoint = "qapplication_exec")]
+        int Exec(IntPtr app);
+        [NativeSymbol(Entrypoint = "qapplication_addTriggerCallback")]
+        void AddTriggerCallback(IntPtr app, IntPtr callback);
+        [NativeSymbol(Entrypoint = "qapplication_requestTrigger")]
+        void RequestTrigger(IntPtr app);
+        [NativeSymbol(Entrypoint = "qapplication_exit")]
+        void Exit(IntPtr app, int returnCode);
+        [NativeSymbol(Entrypoint = "qapplication_internalPointer")]
+        IntPtr InternalPointer(IntPtr app);
+    }
+}


### PR DESCRIPTION
PR for issue https://github.com/qmlnet/qmlnet/issues/73.

Some classes are still using QGuiApplication:
- `Hosts.cs` (Qml.Net project)
- `BaseQmlTests.cs` (Qml.Net.Tests)

Should `QApplication` be the default in all tests? Or should I add seperate tests for `QApplication` and test both?

The `run` function in CoreHost.cpp is almost an exact copy. Perhaps we could remove one, re-use part of the method or allow passing in a more generic (base type or interface) QGuiApplication/QApplication.

Perhaps `QApplication.cs` and `QGuiApplication.cs` could implement an interface named `IQCoreApplication`?

All feedback is welcome, since C++ is not my main language.