### PR TITLE
Cached dynamic delegates for perf increase.

### DIFF
--- a/src/native/QmlNet/QmlNet/types/NetPropertyInfo.cpp
+++ b/src/native/QmlNet/QmlNet/types/NetPropertyInfo.cpp
@@ -66,6 +66,23 @@ void NetPropertyInfo::setNotifySignal(QSharedPointer<NetSignalInfo> signal)
     _notifySignal = std::move(signal);
 }
 
+void NetPropertyInfo::addIndexParameter(QString name, QSharedPointer<NetTypeInfo> typeInfo)
+{
+    _indexParameters.append(QSharedPointer<NetMethodInfoArguement>(new NetMethodInfoArguement(std::move(name), std::move(typeInfo))));
+}
+
+int NetPropertyInfo::getIndexParameterCount()
+{
+    return _indexParameters.size();
+}
+
+QSharedPointer<NetMethodInfoArguement> NetPropertyInfo::getIndexParameter(int index)
+{
+    if(index < 0) return QSharedPointer<NetMethodInfoArguement>(nullptr);
+    if(index >= _indexParameters.length()) return QSharedPointer<NetMethodInfoArguement>(nullptr);
+    return _indexParameters.at(index);
+}
+
 extern "C" {
 
 Q_DECL_EXPORT NetPropertyInfoContainer* property_info_create(NetTypeInfoContainer* parentTypeContainer,
@@ -144,6 +161,25 @@ Q_DECL_EXPORT void property_info_setNotifySignal(NetPropertyInfoContainer* conta
     container->property->setNotifySignal(signalContainer->signal);
 }
 
+Q_DECL_EXPORT void property_info_addIndexParameter(NetPropertyInfoContainer* container, LPWCSTR name, NetTypeInfoContainer* typeInfoContainer)
+{
+    container->property->addIndexParameter(QString::fromUtf16(name), typeInfoContainer->netTypeInfo);
+}
 
+Q_DECL_EXPORT int property_info_getIndexParameterCount(NetPropertyInfoContainer* container)
+{
+    return container->property->getIndexParameterCount();
+}
+
+Q_DECL_EXPORT NetMethodInfoArguementContainer* property_info_getIndexParameter(NetPropertyInfoContainer* container, int index)
+{
+    QSharedPointer<NetMethodInfoArguement> parameter = container->property->getIndexParameter(index);
+    if(parameter == nullptr) {
+        return nullptr;
+    }
+    NetMethodInfoArguementContainer* result = new NetMethodInfoArguementContainer();
+    result->methodArguement = parameter;
+    return result;
+}
 
 }

--- a/src/native/QmlNet/QmlNet/types/NetPropertyInfo.h
+++ b/src/native/QmlNet/QmlNet/types/NetPropertyInfo.h
@@ -2,6 +2,7 @@
 #define NET_TYPE_INFO_PROPERTY_H
 
 #include <QmlNet/types/NetTypeInfo.h>
+#include <QmlNet/types/NetMethodInfo.h>
 
 class NetPropertyInfo {
 public:
@@ -19,6 +20,9 @@ public:
     bool canWrite();
     QSharedPointer<NetSignalInfo> getNotifySignal();
     void setNotifySignal(QSharedPointer<NetSignalInfo> signal);
+    void addIndexParameter(QString name, QSharedPointer<NetTypeInfo> typeInfo);
+    int getIndexParameterCount();
+    QSharedPointer<NetMethodInfoArguement> getIndexParameter(int index);
 private:
     int _id;
     QSharedPointer<NetTypeInfo> _parentType;
@@ -27,6 +31,7 @@ private:
     bool _canRead;
     bool _canWrite;
     QSharedPointer<NetSignalInfo> _notifySignal;
+    QList<QSharedPointer<NetMethodInfoArguement>> _indexParameters;
 };
 
 struct NetPropertyInfoContainer {

--- a/src/net/Qml.Net.Tests/CodeGen/CodeGenParameterTests.cs
+++ b/src/net/Qml.Net.Tests/CodeGen/CodeGenParameterTests.cs
@@ -93,6 +93,26 @@ namespace Qml.Net.Tests.CodeGen
             {
             }
 
+            public virtual void TestObjOfType(RandomType param)
+            {
+            }
+
+            public virtual void TestStruct(RandomStruct param)
+            {
+            }
+
+            public virtual void TestStructNullable(RandomStruct? param)
+            {
+            }
+
+            public virtual void TestEnum(RandomEnum param)
+            {
+            }
+
+            public virtual void TestEnumNullable(RandomEnum? param)
+            {
+            }
+
             public virtual void MultipleParams(int param1, long param2)
             {
             }
@@ -101,6 +121,21 @@ namespace Qml.Net.Tests.CodeGen
             {
                 return 0;
             }
+        }
+
+        public class RandomType
+        {
+        }
+
+        public struct RandomStruct
+        {
+            public int Value;
+        }
+
+        public enum RandomEnum
+        {
+            Value1,
+            Value2
         }
 
         [Fact]
@@ -190,6 +225,30 @@ namespace Qml.Net.Tests.CodeGen
         {
             var o = new object();
             Test(x => x.TestObj(It.Is<object>(v => v.Equals(o))), o);
+        }
+
+        [Fact]
+        public void Can_call_method_with_typed_object_parameter()
+        {
+            var o = new RandomType();
+            Test(x => x.TestObjOfType(It.Is<RandomType>(v => v.Equals(o))), o);
+        }
+
+        [Fact]
+        public void Can_call_method_with_struct_parameter()
+        {
+            var o = new RandomStruct { Value = 2 };
+            Test(x => x.TestStruct(It.Is<RandomStruct>(v => v.Equals(o))), o);
+            Test(x => x.TestStructNullable(It.Is<RandomStruct>(v => v.Equals(o))), o);
+            Test(x => x.TestStructNullable(It.Is<RandomStruct?>(v => v == null)), (RandomStruct?)null);
+        }
+
+        [Fact]
+        public void Can_call_method_with_enum()
+        {
+            Test(x => x.TestEnum(It.Is<RandomEnum>(v => v == RandomEnum.Value2)), RandomEnum.Value2);
+            Test(x => x.TestEnumNullable(It.Is<RandomEnum?>(v => v == RandomEnum.Value2)), RandomEnum.Value2);
+            Test(x => x.TestEnumNullable(It.Is<RandomEnum?>(v => v == null)), (RandomEnum?)null);
         }
 
         [Fact]

--- a/src/net/Qml.Net.Tests/CodeGen/CodeGenReturnTypeTests.cs
+++ b/src/net/Qml.Net.Tests/CodeGen/CodeGenReturnTypeTests.cs
@@ -113,6 +113,30 @@ namespace Qml.Net.Tests.CodeGen
             {
                 return null;
             }
+
+            public virtual RandomType ReturnTypeObjectTyped()
+            {
+                return null;
+            }
+
+            public virtual RandomStruct ReturnTypeStruct()
+            {
+                return new RandomStruct();
+            }
+
+            public virtual RandomStruct? ReturnTypeStructNullable()
+            {
+                return null;
+            }
+        }
+
+        public class RandomType
+        {
+        }
+
+        public struct RandomStruct
+        {
+            public int Value1;
         }
 
         [Fact]
@@ -317,6 +341,41 @@ namespace Qml.Net.Tests.CodeGen
                 result.Instance.Instance.Should().BeSameAs(o);
             });
             Test(x => x.ReturnTypeObject(), null, result =>
+            {
+                result.VariantType.Should().Be(NetVariantType.Invalid);
+            });
+        }
+
+        [Fact]
+        public void Can_return_typed_object()
+        {
+            var o = new RandomType();
+            Test(x => x.ReturnTypeObjectTyped(), o, result =>
+            {
+                result.VariantType.Should().Be(NetVariantType.Object);
+                result.Instance.Instance.Should().BeSameAs(o);
+            });
+            Test(x => x.ReturnTypeObjectTyped(), null, result =>
+            {
+                result.VariantType.Should().Be(NetVariantType.Invalid);
+            });
+        }
+
+        [Fact]
+        public void Can_return_struct()
+        {
+            var value = new RandomStruct();
+            Test(x => x.ReturnTypeStruct(), value, result =>
+            {
+                result.VariantType.Should().Be(NetVariantType.Object);
+                result.Instance.Instance.Should().Be(value);
+            });
+            Test(x => x.ReturnTypeStructNullable(), value, result =>
+            {
+                result.VariantType.Should().Be(NetVariantType.Object);
+                result.Instance.Instance.Should().Be(value);
+            });
+            Test(x => x.ReturnTypeStructNullable(), null, result =>
             {
                 result.VariantType.Should().Be(NetVariantType.Invalid);
             });

--- a/src/net/Qml.Net.Tests/Types/NetTypeManagerTests.cs
+++ b/src/net/Qml.Net.Tests/Types/NetTypeManagerTests.cs
@@ -397,5 +397,29 @@ namespace Qml.Net.Tests.Types
 
             type1.Id.Should().NotBe(type2.Id);
         }
+
+        public class TestType19
+        {
+            public object this[int index]
+            {
+                get => null;
+                set { }
+            }
+        }
+
+        [Fact]
+        public void Can_get_index_parameters()
+        {
+            var type = NetTypeManager.GetTypeInfo<TestType19>();
+            type.EnsureLoaded();
+
+            var prop = type.GetProperty(0);
+            prop.Name.Should().Be("Item");
+
+            var indexParameters = prop.GetAllIndexParameters();
+            indexParameters.Count.Should().Be(1);
+            indexParameters[0].Name.Should().Be("index");
+            indexParameters[0].Type.FullTypeName.Should().Be(typeof(int).AssemblyQualifiedName);
+        }
     }
 }

--- a/src/net/Qml.Net/Internal/CodeGen/CodeGen.Methods.cs
+++ b/src/net/Qml.Net/Internal/CodeGen/CodeGen.Methods.cs
@@ -442,15 +442,7 @@ namespace Qml.Net.Internal.CodeGen
             {
                 using (var variant = list.Get(index))
                 {
-                    if (variant == null || variant.VariantType == NetVariantType.Invalid)
-                    {
-                        return null;
-                    }
-
-                    using (var instance = variant.Instance)
-                    {
-                        return instance?.Instance;
-                    }
+                    return variant?.AsObject();
                 }
             }
         }

--- a/src/net/Qml.Net/Internal/Qml/NetVariant.cs
+++ b/src/net/Qml.Net/Internal/Qml/NetVariant.cs
@@ -140,6 +140,45 @@ namespace Qml.Net.Internal.Qml
             Interop.NetVariant.Clear(Handle);
         }
 
+        public object AsObject()
+        {
+            switch (VariantType)
+            {
+                case NetVariantType.Invalid:
+                    return null;
+                case NetVariantType.Bool:
+                    return Bool;
+                case NetVariantType.Char:
+                    return Char;
+                case NetVariantType.Int:
+                    return Int;
+                case NetVariantType.UInt:
+                    return UInt;
+                case NetVariantType.Long:
+                    return Long;
+                case NetVariantType.ULong:
+                    return ULong;
+                case NetVariantType.Float:
+                    return Float;
+                case NetVariantType.Double:
+                    return Double;
+                case NetVariantType.String:
+                    return String;
+                case NetVariantType.DateTime:
+                    return DateTime;
+                case NetVariantType.Object:
+                    using (var instance = Instance)
+                    {
+                        return instance.Instance;
+                    }
+
+                case NetVariantType.JsValue:
+                    return JsValue.AsDynamic();
+                default:
+                    throw new NotImplementedException($"unhandled type {VariantType}");
+            }
+        }
+
         protected override void DisposeUnmanaged(IntPtr ptr)
         {
             Interop.NetVariant.Destroy(ptr);

--- a/src/net/Qml.Net/Internal/Types/NetPropertyInfo.cs
+++ b/src/net/Qml.Net/Internal/Types/NetPropertyInfo.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Runtime.InteropServices;
 
 namespace Qml.Net.Internal.Types
@@ -70,6 +71,31 @@ namespace Qml.Net.Internal.Types
             }
         }
 
+        public void AddIndexParameter(string name, NetTypeInfo type)
+        {
+            Interop.NetPropertyInfo.AddIndexParameter(Handle, name, type.Handle);
+        }
+
+        public int IndexParameterCount => Interop.NetPropertyInfo.GetIndexParameterCount(Handle);
+
+        public NetMethodInfoParameter GetIndexParameter(int index)
+        {
+            var result = Interop.NetPropertyInfo.GetIndexParameter(Handle, index);
+            if (result == IntPtr.Zero) return null;
+            return new NetMethodInfoParameter(result);
+        }
+
+        public List<NetMethodInfoParameter> GetAllIndexParameters()
+        {
+            var result = new List<NetMethodInfoParameter>();
+            var count = IndexParameterCount;
+            for (var x = 0; x < count; x++)
+            {
+                result.Add(GetIndexParameter(x));
+            }
+            return result;
+        }
+
         protected override void DisposeUnmanaged(IntPtr ptr)
         {
             Interop.NetPropertyInfo.Destroy(ptr);
@@ -133,5 +159,20 @@ namespace Qml.Net.Internal.Types
         public SetNotifySignalDel SetNotifySignal { get; set; }
 
         public delegate void SetNotifySignalDel(IntPtr property, IntPtr signal);
+
+        [NativeSymbol(Entrypoint = "property_info_addIndexParameter")]
+        public AddIndexParameterDel AddIndexParameter { get; set; }
+
+        public delegate void AddIndexParameterDel(IntPtr method, [MarshalAs(UnmanagedType.LPWStr)]string name, IntPtr type);
+
+        [NativeSymbol(Entrypoint = "property_info_getIndexParameterCount")]
+        public GetIndexParameterCountDel GetIndexParameterCount { get; set; }
+
+        public delegate int GetIndexParameterCountDel(IntPtr method);
+
+        [NativeSymbol(Entrypoint = "property_info_getIndexParameter")]
+        public GetIndexParameterDel GetIndexParameter { get; set; }
+
+        public delegate IntPtr GetIndexParameterDel(IntPtr method, int index);
     }
 }


### PR DESCRIPTION
Closes #39.

I haven't don't benchmarks, but this will likely lead to big perf increases. Reflection is used to build the delegates, but after the delegates are built/used, reflection isn't touched.