### PR TITLE
Updated NuGet packages.

### DIFF
--- a/src/net/Qml.Net.Benchmarks/Qml.Net.Benchmarks.csproj
+++ b/src/net/Qml.Net.Benchmarks/Qml.Net.Benchmarks.csproj
@@ -8,6 +8,6 @@
     <ProjectReference Include="..\Qml.Net\Qml.Net.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.11.3" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.11.4" />
   </ItemGroup>
 </Project>

--- a/src/net/Qml.Net.Tests/Qml.Net.Tests.csproj
+++ b/src/net/Qml.Net.Tests/Qml.Net.Tests.csproj
@@ -4,8 +4,8 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.5.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="FluentAssertions" Version="5.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
     <PackageReference Include="Moq" Version="4.10.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />


### PR DESCRIPTION
Updated:
- BenchmarkDotNet from 0.11.3 -> 0.11.4
- FluentAssertions from 5.5.3 -> 5.6.0
- Microsoft.NET.Test.Sdk from 15.9.0 -> 16.0.1