### PR TITLE
Let native callbacks be defined in shared libraries.

### DIFF
--- a/src/native/QmlNet/Hosting/CoreHost.cpp
+++ b/src/native/QmlNet/Hosting/CoreHost.cpp
@@ -27,7 +27,8 @@ static void* getExportedFunction(const char* symbolName) {
     FARPROC symbol = GetProcAddress(library, symbolName);
     return (void*)symbol;
 #else
-    void* dll = dlopen(nullptr, RTLD_LAZY);
+    void* dll = dlopen(nativeModule.isNull() || nativeModule.isEmpty() ? nullptr : nativeModule.toLocal8Bit(),
+                       RTLD_LAZY);
     void* result = dlsym(dll, symbolName);
     dlclose(dll);
     return result;

--- a/src/native/QmlNet/Hosting/CoreHost.cpp
+++ b/src/native/QmlNet/Hosting/CoreHost.cpp
@@ -18,9 +18,11 @@
 #define HOSTFXR_DLL_NAME "libhostfxr.so"
 #endif
 
+static QString nativeModule;
+
 static void* getExportedFunction(const char* symbolName) {
 #ifdef _WIN32
-    HMODULE library = GetModuleHandle(nullptr);
+    HMODULE library = GetModuleHandle(nativeModule.toLocal8Bit());
     FARPROC symbol = GetProcAddress(library, symbolName);
     return (void*)symbol;
 #else
@@ -132,6 +134,8 @@ CoreHost::HostFxrContext CoreHost::findHostFxr()
 
 int CoreHost::run(QGuiApplication& app, QQmlApplicationEngine& engine, runCallback runCallback, RunContext runContext)
 {
+    nativeModule = runContext.nativeModule;
+
     QList<QString> execArgs;
     execArgs.push_back(runContext.entryPoint);
     execArgs.push_back("exec");

--- a/src/native/QmlNet/Hosting/CoreHost.cpp
+++ b/src/native/QmlNet/Hosting/CoreHost.cpp
@@ -22,7 +22,8 @@ static QString nativeModule;
 
 static void* getExportedFunction(const char* symbolName) {
 #ifdef _WIN32
-    HMODULE library = GetModuleHandle(nativeModule.toLocal8Bit());
+    HMODULE library = GetModuleHandle(nativeModule.isNull() || nativeModule.isEmpty() ? nullptr
+                                                                                     : nativeModule.toLocal8Bit());
     FARPROC symbol = GetProcAddress(library, symbolName);
     return (void*)symbol;
 #else

--- a/src/native/QmlNet/Hosting/CoreHost.h
+++ b/src/native/QmlNet/Hosting/CoreHost.h
@@ -26,6 +26,7 @@ public:
         QString entryPoint;
         QString managedExe;
         QList<QString> args;
+        QString nativeModule;
     };
 
     enum LoadHostFxrResult


### PR DESCRIPTION
When using unmanaged hosting, callbacks are currently limited to the top-level executable. We would like to put the callbacks in a shared library, instead. This PR is a rough-draft that shows how I got it working on Windows. Please take a look and let me know if this is the right direction to take or if there's a better way. Thanks.