### PR TITLE
Let NetVariant::fromQJSValue consume all QObject derived types.

### DIFF
--- a/src/native/QmlNet/QmlNet/qml/NetVariant.cpp
+++ b/src/native/QmlNet/QmlNet/qml/NetVariant.cpp
@@ -242,12 +242,12 @@ QSharedPointer<NetVariant> NetVariant::fromQJSValue(const QJSValue& qJsValue)
         // Nothing!
     }
     else if(qJsValue.isQObject()) {
+        result = QSharedPointer<NetVariant>(new NetVariant());
         QObject* qObject = qJsValue.toQObject();
         NetValueInterface* netValue = qobject_cast<NetValueInterface*>(qObject);
         if(!netValue) {
-            qWarning() << "Return type must be a JS type/object, or a .NET object.";
+            result->setQObject(QSharedPointer<NetQObject>(new NetQObject(qObject)));
         } else {
-            result = QSharedPointer<NetVariant>(new NetVariant());
             result->setNetReference(netValue->getNetReference());
         }
     }


### PR DESCRIPTION
A QObject wrapped in a QJSValue can not be passed from C++ to QmlNet even though QObject interaction is now supported for QObject types not derived from NetValueInterface. This PR updates the NetVariant::fromQJSValue function to create a valid NetVariant from any QObject, not just QObject types derived from NetValueInterface.