### PR TITLE
Fix readme quick overview example

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,93 +61,117 @@ Checkout the [examples](https://github.com/qmlnet/qmlnet-examples) for some insp
 **Define a .NET type (POCO)**
 
 ```c#
-[Signal("customSignal", NetVariantType.String)] // You can define signals that Qml can listen to.
-public class QmlType
+//QmlType.cs
+using Qml.Net;
+using System.Threading.Tasks;
+
+namespace QmlQuickOverview
 {
-    /// <summary>
-    /// Properties are exposed to Qml.
-    /// </summary>
-    [NotifySignal("stringPropertyChanged")] // For Qml binding/MVVM.
-    public string StringProperty { get; set; }
+    [Signal("customSignal", NetVariantType.String)] // You can define signals that Qml can listen to.
+    public class QmlType
+    {
+        /// <summary>
+        /// Properties are exposed to Qml.
+        /// </summary>
+        [NotifySignal("stringPropertyChanged")] // For Qml binding/MVVM.
+        public string StringProperty { get; set; }
 
-    /// <summary>
-    /// Methods can return .NET types.
-    /// The returned type can be invoked from Qml (properties/methods/events/etc).
-    /// </summary>
-    /// <returns></returns>
-    public QmlType CreateNetObject()
-    {
-        return new QmlType();
-    }
-
-    /// <summary>
-    /// Qml can pass .NET types to .NET methods.
-    /// </summary>
-    /// <param name="parameter"></param>
-    public void TestMethod(QmlType parameter)
-    {
-    }
-    
-    /// <summary>
-    /// Async methods can be invoked with continuations happening on Qt's main thread.
-    /// </summary>
-    public async Task<string> TestAsync()
-    {
-        // On the UI thread
-        await Task.Run(() =>
+        /// <summary>
+        /// Methods can return .NET types.
+        /// The returned type can be invoked from Qml (properties/methods/events/etc).
+        /// </summary>
+        /// <returns></returns>
+        public QmlType CreateNetObject()
         {
-            // On the background thread
-        });
-        // On the UI thread
-        return "async result!";
-    }
-    
-    /// <summary>
-    /// Qml can also pass Qml/C++ objects that can be invoked from .NET
-    /// </summary>
-    /// <param name="qObject"></param>
-    public void TestMethodWithQObject(dynamic o)
-    {
-        string result = o.propertyDefinedInCpp;
-        o.methodDefinedInCpp(result);
+            return new QmlType();
+        }
+
+        /// <summary>
+        /// Qml can pass .NET types to .NET methods.
+        /// </summary>
+        /// <param name="parameter"></param>
+        public void TestMethod(QmlType parameter)
+        {
+        }
         
-        // You can also listen to signals on QObjects.
-        var qObject = o as INetQObject;
-        var handler = qObject.AttachSignal("signalName", parameters => {
-            // parameters is a list of arguements passed to the signal.
-        });
-        handler.Dispose(); // When you are done listening to signal.
+        /// <summary>
+        /// Async methods can be invoked with continuations happening on Qt's main thread.
+        /// </summary>
+        public async Task<string> TestAsync()
+        {
+            // On the UI thread
+            await Task.Run(() =>
+            {
+                // On the background thread
+            });
+            // On the UI thread
+            return "async result!";
+        }
         
-        // You can also listen to when a property changes (notify signal).
-        handler = qObject.AttachNotifySignal("property", parameters => {
-            // parameters is a list of arguements passed to the signal.
-        });
-        handler.Dispose(); // When you are done listening to signal.
-    }
-    
-    /// <summary>
-    /// .NET can activate signals to send notifications to Qml.
-    /// </summary>
-    public void ActivateCustomSignal(string message)
-    {
-        this.ActivateSignal("customSignal", message);
+        /// <summary>
+        /// Qml can also pass Qml/C++ objects that can be invoked from .NET
+        /// </summary>
+        /// <param name="qObject"></param>
+        public void TestMethodWithQObject(dynamic o)
+        {
+            string result = o.propertyDefinedInCpp;
+            o.methodDefinedInCpp(result);
+            
+            // You can also listen to signals on QObjects.
+            var qObject = o as INetQObject;
+            var handler = qObject.AttachSignal("signalName", parameters => {
+                // parameters is a list of arguements passed to the signal.
+            });
+            handler.Dispose(); // When you are done listening to signal.
+            
+            // You can also listen to when a property changes (notify signal).
+            handler = qObject.AttachNotifySignal("property", parameters => {
+                // parameters is a list of arguements passed to the signal.
+            });
+            handler.Dispose(); // When you are done listening to signal.
+        }
+        
+        /// <summary>
+        /// .NET can activate signals to send notifications to Qml.
+        /// </summary>
+        public void ActivateCustomSignal(string message)
+        {
+            this.ActivateSignal("customSignal", message);
+        }
     }
 }
+
 ```
 
 **Register your new type with Qml.**
 
 ```c#
-using (var app = new QGuiApplication(args))
+//QmlExample.cs
+using Qml.Net;
+using Qml.Net.Runtimes;
+
+namespace QmlQuickOverview
 {
-    using (var engine = new QQmlApplicationEngine())
+    class QmlExample
     {
-        // Register our new type to be used in Qml
-        Qml.Net.Qml.RegisterType<QmlType>("test", 1, 1);
-        engine.Load("main.qml");
-        return app.Exec();
+        static int Main(string[] args)
+        {
+            RuntimeManager.DiscoverOrDownloadSuitableQtRuntime();
+
+            using (var app = new QGuiApplication(args))
+            {
+                using (var engine = new QQmlApplicationEngine())
+                {
+                    // Register our new type to be used in Qml
+                    Qml.Net.Qml.RegisterType<QmlType>("test", 1, 1);
+                    engine.Load("main.qml");
+                    return app.Exec();
+                }
+            }
+        }
     }
 }
+
 ```
 
 **Use the .NET type in Qml**

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ namespace QmlQuickOverview
                 {
                     // Register our new type to be used in Qml
                     Qml.Net.Qml.RegisterType<QmlType>("test", 1, 1);
-                    engine.Load("main.qml");
+                    engine.Load("Main.qml");
                     return app.Exec();
                 }
             }
@@ -177,6 +177,7 @@ namespace QmlQuickOverview
 **Use the .NET type in Qml**
 
 ```js
+//Main.qml
 import QtQuick 2.7
 import QtQuick.Controls 2.0
 import QtQuick.Layouts 1.0


### PR DESCRIPTION
#136 

Modified the example to be fully working and copy-pastable for users new to using QmlNet that would like to test for proper installation before moving forward. The example now includes proper `using` statements as well as a call to `RuntimeManager.DiscoverOrDownloadSuitableQtRuntime();` to prevent exceptions when executing `var app = new QGuiApplication(args)`.

