### PR TITLE
Added PackageId needed for GitHub's dependency graph feature to work

### DIFF
--- a/src/net/Qml.Net/Qml.Net.csproj
+++ b/src/net/Qml.Net/Qml.Net.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <PackageId>Qml.Net</PackageId>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />


### PR DESCRIPTION
Right now Github doesn't see any packages provided by this repository - https://github.com/qmlnet/qmlnet/network/dependents