### PR TITLE
Replace usage of QString::asprintf

### DIFF
--- a/src/native/QmlNet/Hosting/CoreHost.cpp
+++ b/src/native/QmlNet/Hosting/CoreHost.cpp
@@ -143,14 +143,10 @@ int CoreHost::run(QGuiApplication& app, QQmlApplicationEngine& engine, runCallba
     execArgs.push_back("exec");
     execArgs.push_back(runContext.managedExe);
 
-    QString appPtr;
-    appPtr.asprintf("%llu", (quintptr)&app);
-    QString enginePtr;
-    enginePtr.asprintf("%llu", (quintptr)&engine);
-    QString callbackPtr;
-    callbackPtr.asprintf("%llu", (quintptr)runCallback);
-    QString exportedSymbolPointer;
-    exportedSymbolPointer.asprintf("%llu", (quintptr)getExportedFunction);
+    auto appPtr = QString::number((qintptr)&app);
+    auto enginePtr = QString::number((quintptr)&engine);
+    auto callbackPtr = QString::number((quintptr)runCallback);
+    auto exportedSymbolPointer = QString::number((quintptr)&getExportedFunction);
 
     execArgs.push_back(appPtr);
     execArgs.push_back(enginePtr);


### PR DESCRIPTION
In Qt5, `QString::asprintf` is a static method which returns a new string, rather than an instance method which updates the existing string (as it was in Qt4), so the code was passing empty strings to the managed entry point. Additionally, [the documentation warns against it](https://doc.qt.io/qt-5/qstring.html#asprintf).

The static [QString::number](https://doc.qt.io/qt-5/qstring.html#number) method is available in both Qt4 and Qt5. I haven't tested against Qt4 but it works in 5.14.2.