### PR TITLE
Fail Tests on QML Warnings

### DIFF
--- a/src/net/Qml.Net.Tests/Qml/BaseQmlTests.cs
+++ b/src/net/Qml.Net.Tests/Qml/BaseQmlTests.cs
@@ -33,7 +33,7 @@ namespace Qml.Net.Tests.Qml
             Net.Qml.RegisterType<T>("tests");
         }
 
-        protected void RunQmlTest(string instanceId, string componentOnCompletedCode, bool runEvents = false)
+        protected void RunQmlTest(string instanceId, string componentOnCompletedCode, bool runEvents = false, bool failOnQmlWarnings = true)
         {
             var result = NetTestHelper.RunQml(
                 qmlApplicationEngine,
@@ -52,7 +52,8 @@ namespace Qml.Net.Tests.Qml
                     typeof(TTypeToRegister).Name,
                     instanceId,
                     componentOnCompletedCode),
-                runEvents);
+                runEvents,
+                failOnQmlWarnings);
             if (result == false)
             {
                 throw new Exception($"Couldn't execute qml: {componentOnCompletedCode}");

--- a/src/net/Qml.Net.Tests/Qml/SignalTests.cs
+++ b/src/net/Qml.Net.Tests/Qml/SignalTests.cs
@@ -231,6 +231,7 @@ namespace Qml.Net.Tests.Qml
                     })
                     test.someBoolProperty = true
                 ",
+                // TODO: Review/remove the test
                 failOnQmlWarnings: false);
 
             Mock.VerifySet(x => x.SignalRaised = true, Times.Never);

--- a/src/net/Qml.Net.Tests/Qml/SignalTests.cs
+++ b/src/net/Qml.Net.Tests/Qml/SignalTests.cs
@@ -230,7 +230,8 @@ namespace Qml.Net.Tests.Qml
                         test.signalRaised = true
                     })
                     test.someBoolProperty = true
-                ");
+                ",
+                failOnQmlWarnings: false);
 
             Mock.VerifySet(x => x.SignalRaised = true, Times.Never);
         }

--- a/src/net/Qml.Net/Internal/Qml/NetTestHelper.cs
+++ b/src/net/Qml.Net/Internal/Qml/NetTestHelper.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Security;
 
@@ -6,19 +7,29 @@ namespace Qml.Net.Internal.Qml
 {
     internal class NetTestHelper
     {
-        public static bool RunQml(QQmlApplicationEngine qmlEngine, string qml, bool runEvents = false)
+        public static bool RunQml(QQmlApplicationEngine qmlEngine, string qml, bool runEvents = false, bool failOnQmlWarnings = true)
         {
-            return Interop.NetTestHelper.RunQml(qmlEngine.Handle, qml, runEvents ? (byte)1 : (byte)0) == 1;
+            var warnings = new List<string>();
+            var result = Interop.NetTestHelper.RunQml(qmlEngine.Handle, qml, runEvents ? (byte)1 : (byte)0, warnings.Add);
+            if (warnings.Count > 0 && failOnQmlWarnings)
+            {
+                throw new Exception(string.Join("\n", warnings));
+            }
+
+            return result == 1;
         }
     }
 
     internal class NetTestHelperInterop
     {
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+        public delegate void WarningDel(string text);
+
         [NativeSymbol(Entrypoint = "net_test_helper_runQml")]
         public RunQmlDel RunQml { get; set; }
 
         [SuppressUnmanagedCodeSecurity]
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        public delegate byte RunQmlDel(IntPtr qmlEngine, [MarshalAs(UnmanagedType.LPWStr)]string qml, byte runEvents);
+        public delegate byte RunQmlDel(IntPtr qmlEngine, [MarshalAs(UnmanagedType.LPWStr)] string qml, byte runEvents, WarningDel onWarning);
     }
 }


### PR DESCRIPTION
Runtime errors when running the QML parts of unit tests are currently ignored and not captured in test output. Warnings are now captured and if not explicitly disabled, any QML warning will fail the test and include the warning messages in the failure.

I came across this while writing tests for #201, since runtime failures were silently ignored, leading to a test assertion failure that was awfully hard to debug. With this change, such runtime errors (i.e. trying to access undefined properties) will now lead to an immediate test failure, and will include the proper messages.

What we would probably also want is to capture all QML warnings in the XUnit test output, but that would require us to pass through the ITestOutputHelper through _all_ test constructors to the base class, which is a pain...