### PR TITLE
Use QChar* instead of custom string typedefs

### DIFF
--- a/src/native/QmlNet/QmlNet.h
+++ b/src/native/QmlNet/QmlNet.h
@@ -5,37 +5,6 @@
 
 #define NetGCHandle void
 
-#if _MSC_VER
-    typedef const wchar_t* BCSTR;
-    typedef const char* LPCSTR;
-    typedef const char16_t* LPWCSTR;
-    typedef char16_t* LPWSTR;
-#endif
-
-#if !_MSC_VER
-    #define __declspec(dllexport)
-    #define __stdcall
-
-    typedef char16_t* BSTR;
-    typedef const char16_t* BCSTR;
-
-    typedef char* LPSTR;
-    typedef const char* LPCSTR;
-
-    typedef char16_t* LPWSTR;
-    typedef const char16_t* LPWCSTR;
-
-    #if UNICODE
-        #define LPTSTR(value) (LPTSTR)u ##value;
-        typedef LPWSTR LPTSTR;
-        typedef LPWCSTR LPTCSTR;
-    #else
-        #define LPTSTR(value) value;
-        typedef LPSTR LPTSTR;
-        typedef LPCSTR LPTCSTR;
-    #endif
-#endif
-
 enum NetVariantTypeEnum {
     NetVariantTypeEnum_Invalid = 0,
     NetVariantTypeEnum_Null,

--- a/src/native/QmlNet/QmlNet/qml/NetJsValue.cpp
+++ b/src/native/QmlNet/QmlNet/qml/NetJsValue.cpp
@@ -112,8 +112,8 @@ Q_DECL_EXPORT NetVariantContainer* net_js_value_call(NetJSValueContainer* jsValu
     return nullptr;
 }
 
-Q_DECL_EXPORT NetVariantContainer* net_js_value_getProperty(NetJSValueContainer* jsValueContainer, LPWSTR propertyName) {
-    QSharedPointer<NetVariant> result = jsValueContainer->jsValue->getProperty(QString::fromUtf16(static_cast<const char16_t*>(propertyName)));
+Q_DECL_EXPORT NetVariantContainer* net_js_value_getProperty(NetJSValueContainer* jsValueContainer, QChar* propertyName) {
+    QSharedPointer<NetVariant> result = jsValueContainer->jsValue->getProperty(QString(propertyName));
     if(result == nullptr) {
         return nullptr;
     }
@@ -128,12 +128,12 @@ Q_DECL_EXPORT NetVariantContainer* net_js_value_getItemAtIndex(NetJSValueContain
     return new NetVariantContainer{result};
 }
 
-Q_DECL_EXPORT void net_js_value_setProperty(NetJSValueContainer* jsValueContainer, LPWSTR propertyName, NetVariantContainer* valueContainer) {
+Q_DECL_EXPORT void net_js_value_setProperty(NetJSValueContainer* jsValueContainer, QChar* propertyName, NetVariantContainer* valueContainer) {
     QSharedPointer<NetVariant> value;
     if(valueContainer != nullptr) {
         value = valueContainer->variant;
     }
-    jsValueContainer->jsValue->setProperty(QString::fromUtf16(static_cast<const char16_t*>(propertyName)), value);
+    jsValueContainer->jsValue->setProperty(QString(propertyName), value);
 }
 
 Q_DECL_EXPORT void net_js_value_setItemAtIndex(NetJSValueContainer* jsValueContainer, quint32 arrayIndex, NetVariantContainer* valueContainer) {

--- a/src/native/QmlNet/QmlNet/qml/NetQObject.cpp
+++ b/src/native/QmlNet/QmlNet/qml/NetQObject.cpp
@@ -297,10 +297,10 @@ Q_DECL_EXPORT void net_qobject_destroy(NetQObjectContainer* qObjectContainer)
     delete qObjectContainer;
 }
 
-Q_DECL_EXPORT NetVariantContainer* net_qobject_getProperty(NetQObjectContainer* qObjectContainer, LPWCSTR propertyName, uchar* result)
+Q_DECL_EXPORT NetVariantContainer* net_qobject_getProperty(NetQObjectContainer* qObjectContainer, const QChar* propertyName, uchar* result)
 {
     bool wasSuccesful = false;
-    auto value = qObjectContainer->qObject->getProperty(QString::fromUtf16(propertyName), &wasSuccesful);
+    auto value = qObjectContainer->qObject->getProperty(QString(propertyName), &wasSuccesful);
     if(wasSuccesful) {
         *result = 1;
     } else {
@@ -312,13 +312,13 @@ Q_DECL_EXPORT NetVariantContainer* net_qobject_getProperty(NetQObjectContainer* 
     return new NetVariantContainer{ value };
 }
 
-Q_DECL_EXPORT void net_qobject_setProperty(NetQObjectContainer* qObjectContainer, LPWCSTR propertyName, NetVariantContainer* netVariantContainer, uchar* result)
+Q_DECL_EXPORT void net_qobject_setProperty(NetQObjectContainer* qObjectContainer, const QChar* propertyName, NetVariantContainer* netVariantContainer, uchar* result)
 {
     bool wasSuccesful = false;
     if(netVariantContainer == nullptr) {
-        qObjectContainer->qObject->setProperty(QString::fromUtf16(propertyName), nullptr, &wasSuccesful);
+        qObjectContainer->qObject->setProperty(QString(propertyName), nullptr, &wasSuccesful);
     } else {
-        qObjectContainer->qObject->setProperty(QString::fromUtf16(propertyName), netVariantContainer->variant, &wasSuccesful);
+        qObjectContainer->qObject->setProperty(QString(propertyName), netVariantContainer->variant, &wasSuccesful);
     }
     if(wasSuccesful) {
         *result = 1;
@@ -327,14 +327,14 @@ Q_DECL_EXPORT void net_qobject_setProperty(NetQObjectContainer* qObjectContainer
     }
 }
 
-Q_DECL_EXPORT NetVariantContainer* net_qobject_invokeMethod(NetQObjectContainer* qObjectContainer, LPWCSTR methodName, NetVariantListContainer* parametersContainer, uchar* result)
+Q_DECL_EXPORT NetVariantContainer* net_qobject_invokeMethod(NetQObjectContainer* qObjectContainer, const QChar* methodName, NetVariantListContainer* parametersContainer, uchar* result)
 {
     QSharedPointer<NetVariantList> parameters = nullptr;
     if(parametersContainer != nullptr) {
         parameters = parametersContainer->list;
     }
     bool wasSuccesful = false;
-    auto value = qObjectContainer->qObject->invokeMethod(QString::fromUtf16(methodName), parameters, &wasSuccesful);
+    auto value = qObjectContainer->qObject->invokeMethod(QString(methodName), parameters, &wasSuccesful);
     if(wasSuccesful) {
         *result = 1;
     } else {
@@ -346,10 +346,10 @@ Q_DECL_EXPORT NetVariantContainer* net_qobject_invokeMethod(NetQObjectContainer*
     return new NetVariantContainer { value };
 }
 
-Q_DECL_EXPORT NetQObjectSignalConnectionContainer* net_qobject_attachSignal(NetQObjectContainer* qObjectContainer, LPWCSTR signalName, NetReferenceContainer* delegate, uchar* result)
+Q_DECL_EXPORT NetQObjectSignalConnectionContainer* net_qobject_attachSignal(NetQObjectContainer* qObjectContainer, const QChar* signalName, NetReferenceContainer* delegate, uchar* result)
 {
     bool wasSuccesful = false;
-    auto signalConnection = qObjectContainer->qObject->attachSignal(QString::fromUtf16(signalName), delegate->instance, &wasSuccesful);
+    auto signalConnection = qObjectContainer->qObject->attachSignal(QString(signalName), delegate->instance, &wasSuccesful);
     if(wasSuccesful) {
         *result = 1;
     } else {
@@ -361,10 +361,10 @@ Q_DECL_EXPORT NetQObjectSignalConnectionContainer* net_qobject_attachSignal(NetQ
     return new NetQObjectSignalConnectionContainer { signalConnection };
 }
 
-Q_DECL_EXPORT NetQObjectSignalConnectionContainer* net_qobject_attachNotifySignal(NetQObjectContainer* qObjectContainer, LPWCSTR propertyName, NetReferenceContainer* delegate, uchar* result)
+Q_DECL_EXPORT NetQObjectSignalConnectionContainer* net_qobject_attachNotifySignal(NetQObjectContainer* qObjectContainer, const QChar* propertyName, NetReferenceContainer* delegate, uchar* result)
 {
     bool wasSuccesful = false;
-    auto signalConnection = qObjectContainer->qObject->attachNotifySignal(QString::fromUtf16(propertyName), delegate->instance, &wasSuccesful);
+    auto signalConnection = qObjectContainer->qObject->attachNotifySignal(QString(propertyName), delegate->instance, &wasSuccesful);
     if(wasSuccesful) {
         *result = 1;
     } else {
@@ -376,13 +376,13 @@ Q_DECL_EXPORT NetQObjectSignalConnectionContainer* net_qobject_attachNotifySigna
     return new NetQObjectSignalConnectionContainer { signalConnection };
 }
 
-Q_DECL_EXPORT NetQObjectContainer* net_qobject_buildQObject(LPWCSTR className, NetVariantListContainer* constructorParameters)
+Q_DECL_EXPORT NetQObjectContainer* net_qobject_buildQObject(const QChar* className, NetVariantListContainer* constructorParameters)
 {
     QSharedPointer<NetVariantList> params;
     if(constructorParameters) {
         params = constructorParameters->list;
     }
-    QSharedPointer<NetQObject> result = NetQObject::buildQObject(QString::fromUtf16(className), params);
+    QSharedPointer<NetQObject> result = NetQObject::buildQObject(QString(className), params);
     if(result == nullptr) {
         return nullptr;
     }

--- a/src/native/QmlNet/QmlNet/qml/NetTestHelper.cpp
+++ b/src/native/QmlNet/QmlNet/qml/NetTestHelper.cpp
@@ -212,7 +212,7 @@ extern "C" {
 
 using WarningCallback = void(const QChar*);
 
-Q_DECL_EXPORT uchar net_test_helper_runQml(QQmlApplicationEngineContainer* qmlEngineContainer, LPWSTR qml, uchar runEvents, WarningCallback *warningCallback)
+Q_DECL_EXPORT uchar net_test_helper_runQml(QQmlApplicationEngineContainer* qmlEngineContainer, QChar* qml, uchar runEvents, WarningCallback *warningCallback)
 {
     qRegisterMetaType<TestBaseQObject*>();
     qRegisterMetaType<TestQObject*>();
@@ -226,7 +226,7 @@ Q_DECL_EXPORT uchar net_test_helper_runQml(QQmlApplicationEngineContainer* qmlEn
     });
 
     QQmlComponent component(qmlEngineContainer->qmlEngine);
-    QString qmlString = QString::fromUtf16(static_cast<const char16_t*>(qml));
+    QString qmlString(qml);
     component.setData(qmlString.toUtf8(), QUrl());
 
     QObject *object = component.create();

--- a/src/native/QmlNet/QmlNet/qml/NetVariant.cpp
+++ b/src/native/QmlNet/QmlNet/qml/NetVariant.cpp
@@ -660,11 +660,11 @@ Q_DECL_EXPORT double net_variant_getDouble(NetVariantContainer* container) {
     return container->variant->getDouble();
 }
 
-Q_DECL_EXPORT void net_variant_setString(NetVariantContainer* container, LPWSTR value) {
+Q_DECL_EXPORT void net_variant_setString(NetVariantContainer* container, QChar* value) {
     if(value == nullptr) {
         container->variant->setString(nullptr);
     } else {
-        container->variant->setString(QString::fromUtf16(static_cast<const char16_t*>(value)));
+        container->variant->setString(QString(value));
     }
 }
 
@@ -676,7 +676,7 @@ Q_DECL_EXPORT QmlNetStringContainer* net_variant_getString(NetVariantContainer* 
     return createString(string);
 }
 
-Q_DECL_EXPORT void net_variant_setBytes(NetVariantContainer* container, LPCSTR value, int count) {
+Q_DECL_EXPORT void net_variant_setBytes(NetVariantContainer* container, const char* value, int count) {
     if(value == nullptr) {
         container->variant->setBytes(nullptr);
     } else {
@@ -684,7 +684,7 @@ Q_DECL_EXPORT void net_variant_setBytes(NetVariantContainer* container, LPCSTR v
     }
 }
 
-Q_DECL_EXPORT LPCSTR net_variant_getBytes(NetVariantContainer* container, int &count) {
+Q_DECL_EXPORT const char* net_variant_getBytes(NetVariantContainer* container, int &count) {
     const QByteArray byteArray = container->variant->getBytes();
     if(byteArray.isNull()) {
         count = 0;

--- a/src/native/QmlNet/QmlNet/qml/QCommon.cpp
+++ b/src/native/QmlNet/QmlNet/qml/QCommon.cpp
@@ -5,7 +5,7 @@
 
 extern "C" {
 
-Q_DECL_EXPORT uchar qt_putenv(LPCSTR name, LPCSTR value)
+Q_DECL_EXPORT uchar qt_putenv(const char* name, const char* value)
 {
     if(value == nullptr) {
         if(qunsetenv(name)) {
@@ -22,7 +22,7 @@ Q_DECL_EXPORT uchar qt_putenv(LPCSTR name, LPCSTR value)
     }
 }
 
-Q_DECL_EXPORT QmlNetStringContainer* qt_getenv(LPCSTR name)
+Q_DECL_EXPORT QmlNetStringContainer* qt_getenv(const char* name)
 {
     QByteArray result = qgetenv(name);
     if(result.isNull()) {

--- a/src/native/QmlNet/QmlNet/qml/QCoreApplication.cpp
+++ b/src/native/QmlNet/QmlNet/qml/QCoreApplication.cpp
@@ -187,9 +187,9 @@ Q_DECL_EXPORT QCoreApplication* qapp_internalPointer(QGuiApplicationContainer* c
     return container->app;
 }
 
-Q_DECL_EXPORT void qapp_setOrganizationName(LPWCSTR organizationName)
+Q_DECL_EXPORT void qapp_setOrganizationName(const QChar* organizationName)
 {
-    QCoreApplication::setOrganizationName(QString::fromUtf16(organizationName));
+    QCoreApplication::setOrganizationName(QString(organizationName));
 }
 
 Q_DECL_EXPORT QmlNetStringContainer* qapp_getOrganizationName()
@@ -197,9 +197,9 @@ Q_DECL_EXPORT QmlNetStringContainer* qapp_getOrganizationName()
     return createString(QCoreApplication::organizationName());
 }
 
-Q_DECL_EXPORT void qapp_setOrganizationDomain(LPWCSTR organizationDomain)
+Q_DECL_EXPORT void qapp_setOrganizationDomain(const QChar* organizationDomain)
 {
-    QCoreApplication::setOrganizationDomain(QString::fromUtf16(organizationDomain));
+    QCoreApplication::setOrganizationDomain(QString(organizationDomain));
 }
 
 Q_DECL_EXPORT QmlNetStringContainer* qapp_getOrganizationDomain()

--- a/src/native/QmlNet/QmlNet/qml/QLocaleInterop.cpp
+++ b/src/native/QmlNet/QmlNet/qml/QLocaleInterop.cpp
@@ -5,7 +5,7 @@
 
 extern "C" {
 
-Q_DECL_EXPORT QmlNetStringContainer* qlocale_set_default_name(LPCSTR name)
+Q_DECL_EXPORT QmlNetStringContainer* qlocale_set_default_name(const char* name)
 {
     QLocale locale = QLocale(QString(name));
     QLocale::setDefault(locale);

--- a/src/native/QmlNet/QmlNet/qml/QQmlApplicationEngine.cpp
+++ b/src/native/QmlNet/QmlNet/qml/QQmlApplicationEngine.cpp
@@ -60,18 +60,18 @@ Q_DECL_EXPORT void qqmlapplicationengine_destroy(QQmlApplicationEngineContainer*
     delete container;
 }
 
-Q_DECL_EXPORT void qqmlapplicationengine_load(QQmlApplicationEngineContainer* container, LPWSTR path) {
-    container->qmlEngine->load(QString::fromUtf16(static_cast<const char16_t*>(path)));
+Q_DECL_EXPORT void qqmlapplicationengine_load(QQmlApplicationEngineContainer* container, QChar* path) {
+    container->qmlEngine->load(QString(path));
 }
 
-Q_DECL_EXPORT void qqmlapplicationengine_loadData(QQmlApplicationEngineContainer* container, LPWSTR dataString) {
-    container->qmlEngine->loadData(QByteArray::fromStdString(QString::fromUtf16(static_cast<const char16_t*>(dataString)).toStdString()));
+Q_DECL_EXPORT void qqmlapplicationengine_loadData(QQmlApplicationEngineContainer* container, QChar* dataString) {
+    container->qmlEngine->loadData(QByteArray::fromStdString(QString(dataString).toStdString()));
 }
 
-Q_DECL_EXPORT int qqmlapplicationengine_registerType(NetTypeInfoContainer* typeContainer, LPWSTR uri, int versionMajor, int versionMinor, LPWSTR qmlName) {
+Q_DECL_EXPORT int qqmlapplicationengine_registerType(NetTypeInfoContainer* typeContainer, QChar* uri, int versionMajor, int versionMinor, QChar* qmlName) {
 
-    QString uriString = QString::fromUtf16(static_cast<const char16_t*>(uri));
-    QString qmlNameString = QString::fromUtf16(static_cast<const char16_t*>(qmlName));
+    QString uriString(uri);
+    QString qmlNameString(qmlName);
     QSharedPointer<NetTypeInfo> typeInfo = typeContainer->netTypeInfo;
 
     switch (++netValueTypeNumber) {
@@ -260,19 +260,19 @@ Q_DECL_EXPORT int qqmlapplicationengine_registerType(NetTypeInfoContainer* typeC
     return -1;
 }
 
-Q_DECL_EXPORT int qqmlapplicationengine_registerSingletonTypeQml(LPWCSTR url, LPWCSTR uri, int versionMajor, int versionMinor, LPWCSTR qmlName)
+Q_DECL_EXPORT int qqmlapplicationengine_registerSingletonTypeQml(const QChar* url, const QChar* uri, int versionMajor, int versionMinor, const QChar* qmlName)
 {
-    QString urlString = QString::fromUtf16(url);
-    QString uriString = QString::fromUtf16(uri);
-    QString qmlNameString = QString::fromUtf16(qmlName);
+    QString urlString(url);
+    QString uriString(uri);
+    QString qmlNameString(qmlName);
     return qmlRegisterSingletonType(urlString, uriString.toUtf8().data(), versionMajor, versionMinor, qmlNameString.toUtf8().data());
 }
 
-Q_DECL_EXPORT int qqmlapplicationengine_registerSingletonTypeNet(NetTypeInfoContainer* typeContainer, LPWCSTR uri, int versionMajor, int versionMinor, LPWCSTR typeName)
+Q_DECL_EXPORT int qqmlapplicationengine_registerSingletonTypeNet(NetTypeInfoContainer* typeContainer, const QChar* uri, int versionMajor, int versionMinor, const QChar* typeName)
 {
     QSharedPointer<NetTypeInfo> typeInfo = typeContainer->netTypeInfo;
-    QString typeNameString = QString::fromUtf16(typeName);
-    QString uriString = QString::fromUtf16(uri);
+    QString typeNameString(typeName);
+    QString uriString(uri);
 
     switch (++netValueTypeNumber) {
         NETVALUETYPESINGLETON_CASE(1)
@@ -460,8 +460,8 @@ Q_DECL_EXPORT int qqmlapplicationengine_registerSingletonTypeNet(NetTypeInfoCont
     return -1;
 }
 
-Q_DECL_EXPORT void qqmlapplicationengine_addImportPath(QQmlApplicationEngineContainer* container, LPWSTR path) {
-    QString pathString = QString::fromUtf16(static_cast<const char16_t*>(path));
+Q_DECL_EXPORT void qqmlapplicationengine_addImportPath(QQmlApplicationEngineContainer* container, QChar* path) {
+    QString pathString = QString(path);
     container->qmlEngine->addImportPath(pathString);
 }
 
@@ -469,21 +469,21 @@ Q_DECL_EXPORT QQmlApplicationEngine* qqmlapplicationengine_internalPointer(QQmlA
     return container->qmlEngine;
 }
 
-Q_DECL_EXPORT NetVariantContainer* qqmlapplicationengine_getContextProperty(QQmlApplicationEngineContainer* container, LPWCSTR name)
+Q_DECL_EXPORT NetVariantContainer* qqmlapplicationengine_getContextProperty(QQmlApplicationEngineContainer* container, const QChar* name)
 {
-    QVariant result = container->qmlEngine->rootContext()->contextProperty(QString::fromUtf16(name));
+    QVariant result = container->qmlEngine->rootContext()->contextProperty(QString(name));
     return new NetVariantContainer {
         NetVariant::fromQVariant(&result)
     };
 }
 
-Q_DECL_EXPORT void qqmlapplicationengine_setContextProperty(QQmlApplicationEngineContainer* container, LPWCSTR name, NetVariantContainer* valueContainer)
+Q_DECL_EXPORT void qqmlapplicationengine_setContextProperty(QQmlApplicationEngineContainer* container, const QChar* name, NetVariantContainer* valueContainer)
 {
     if(valueContainer == nullptr) {
-        container->qmlEngine->rootContext()->setContextProperty(QString::fromUtf16(name), nullptr);
+        container->qmlEngine->rootContext()->setContextProperty(QString(name), nullptr);
     } else {
         QSharedPointer<NetVariant> value = valueContainer->variant;
-        container->qmlEngine->rootContext()->setContextProperty(QString::fromUtf16(name), value->toQVariant());
+        container->qmlEngine->rootContext()->setContextProperty(QString(name), value->toQVariant());
     }
 }
 

--- a/src/native/QmlNet/QmlNet/qml/QQuickStyle.cpp
+++ b/src/native/QmlNet/QmlNet/qml/QQuickStyle.cpp
@@ -3,14 +3,14 @@
 
 extern "C" {
 
-Q_DECL_EXPORT void qquickstyle_setFallbackStyle(LPWCSTR style)
+Q_DECL_EXPORT void qquickstyle_setFallbackStyle(const QChar* style)
 {
-    QQuickStyle::setFallbackStyle(QString::fromUtf16(style));
+    QQuickStyle::setFallbackStyle(QString(style));
 }
 
-Q_DECL_EXPORT void qquickstyle_setStyle(LPWCSTR style)
+Q_DECL_EXPORT void qquickstyle_setStyle(const QChar* style)
 {
-    QQuickStyle::setStyle(QString::fromUtf16(style));
+    QQuickStyle::setStyle(QString(style));
 }
 
 }

--- a/src/native/QmlNet/QmlNet/qml/QResource.cpp
+++ b/src/native/QmlNet/QmlNet/qml/QResource.cpp
@@ -4,9 +4,9 @@
 
 extern "C" {
 
-Q_DECL_EXPORT uchar qresource_registerResource(LPWSTR rccFileName, LPWSTR resourceRoot) {
-    QString rccFileNameString = QString::fromUtf16(static_cast<const char16_t*>(rccFileName));
-    QString resourceRootString = QString::fromUtf16(static_cast<const char16_t*>(resourceRoot));
+Q_DECL_EXPORT uchar qresource_registerResource(QChar* rccFileName, QChar* resourceRoot) {
+    QString rccFileNameString(rccFileName);
+    QString resourceRootString(resourceRoot);
     if(QResource::registerResource(rccFileNameString, resourceRootString)) {
         return 1;
     } else{
@@ -14,9 +14,9 @@ Q_DECL_EXPORT uchar qresource_registerResource(LPWSTR rccFileName, LPWSTR resour
     }
 }
 
-Q_DECL_EXPORT uchar qresource_unregisterResource(LPWSTR rccFileName, LPWSTR resourceRoot) {
-    QString rccFileNameString = QString::fromUtf16(static_cast<const char16_t*>(rccFileName));
-    QString resourceRootString = QString::fromUtf16(static_cast<const char16_t*>(resourceRoot));
+Q_DECL_EXPORT uchar qresource_unregisterResource(QChar* rccFileName, QChar* resourceRoot) {
+    QString rccFileNameString(rccFileName);
+    QString resourceRootString(resourceRoot);
     if(QResource::unregisterResource(rccFileNameString, resourceRootString)) {
         return 1;
     } else {

--- a/src/native/QmlNet/QmlNet/types/NetMethodInfo.cpp
+++ b/src/native/QmlNet/QmlNet/types/NetMethodInfo.cpp
@@ -126,7 +126,7 @@ Q_DECL_EXPORT NetTypeInfoContainer* method_info_parameter_getType(NetMethodInfoA
     return result;
 }
 
-Q_DECL_EXPORT NetMethodInfoContainer* method_info_create(NetTypeInfoContainer* parentTypeContainer, LPWSTR methodName, NetTypeInfoContainer* returnTypeContainer, uchar isStatic)
+Q_DECL_EXPORT NetMethodInfoContainer* method_info_create(NetTypeInfoContainer* parentTypeContainer, QChar* methodName, NetTypeInfoContainer* returnTypeContainer, uchar isStatic)
 {
     NetMethodInfoContainer* result = new NetMethodInfoContainer();
 
@@ -140,7 +140,7 @@ Q_DECL_EXPORT NetMethodInfoContainer* method_info_create(NetTypeInfoContainer* p
         returnType = returnTypeContainer->netTypeInfo;
     }
 
-    NetMethodInfo* instance = new NetMethodInfo(parentType, QString::fromUtf16(static_cast<const char16_t*>(methodName)), returnType, isStatic == 1 ? true : false);
+    NetMethodInfo* instance = new NetMethodInfo(parentType, QString(methodName), returnType, isStatic == 1 ? true : false);
     result->method = QSharedPointer<NetMethodInfo>(instance);
     return result;
 }
@@ -186,9 +186,9 @@ Q_DECL_EXPORT uchar method_info_isStatic(NetMethodInfoContainer* container)
     }
 }
 
-Q_DECL_EXPORT void method_info_addParameter(NetMethodInfoContainer* container, LPWSTR name, NetTypeInfoContainer* typeInfoContainer)
+Q_DECL_EXPORT void method_info_addParameter(NetMethodInfoContainer* container, QChar* name, NetTypeInfoContainer* typeInfoContainer)
 {
-    container->method->addParameter(QString::fromUtf16(static_cast<const char16_t*>(name)), typeInfoContainer->netTypeInfo);
+    container->method->addParameter(QString(name), typeInfoContainer->netTypeInfo);
 }
 
 Q_DECL_EXPORT int method_info_getParameterCount(NetMethodInfoContainer* container)

--- a/src/native/QmlNet/QmlNet/types/NetPropertyInfo.cpp
+++ b/src/native/QmlNet/QmlNet/types/NetPropertyInfo.cpp
@@ -86,7 +86,7 @@ QSharedPointer<NetMethodInfoArguement> NetPropertyInfo::getIndexParameter(int in
 extern "C" {
 
 Q_DECL_EXPORT NetPropertyInfoContainer* property_info_create(NetTypeInfoContainer* parentTypeContainer,
-                                               LPWSTR name,
+                                               QChar* name,
                                                NetTypeInfoContainer* returnType,
                                                uchar canRead,
                                                uchar canWrite,
@@ -97,7 +97,7 @@ Q_DECL_EXPORT NetPropertyInfoContainer* property_info_create(NetTypeInfoContaine
         notifySignal = notifySignalContainer->signal;
     }
     NetPropertyInfo* instance = new NetPropertyInfo(parentTypeContainer->netTypeInfo,
-                                                    QString::fromUtf16(static_cast<const char16_t*>(name)),
+                                                    QString(name),
                                                     returnType->netTypeInfo,
                                                     canRead == 1 ? true  : false,
                                                     canWrite == 1 ? true : false,
@@ -161,9 +161,9 @@ Q_DECL_EXPORT void property_info_setNotifySignal(NetPropertyInfoContainer* conta
     container->property->setNotifySignal(signalContainer->signal);
 }
 
-Q_DECL_EXPORT void property_info_addIndexParameter(NetPropertyInfoContainer* container, LPWCSTR name, NetTypeInfoContainer* typeInfoContainer)
+Q_DECL_EXPORT void property_info_addIndexParameter(NetPropertyInfoContainer* container, const QChar* name, NetTypeInfoContainer* typeInfoContainer)
 {
-    container->property->addIndexParameter(QString::fromUtf16(name), typeInfoContainer->netTypeInfo);
+    container->property->addIndexParameter(QString(name), typeInfoContainer->netTypeInfo);
 }
 
 Q_DECL_EXPORT int property_info_getIndexParameterCount(NetPropertyInfoContainer* container)

--- a/src/native/QmlNet/QmlNet/types/NetReference.cpp
+++ b/src/native/QmlNet/QmlNet/types/NetReference.cpp
@@ -55,14 +55,14 @@ Q_DECL_EXPORT uint64_t net_instance_getObjectId(NetReferenceContainer* container
     return container->instance->getObjectId();
 }
 
-Q_DECL_EXPORT uchar net_instance_activateSignal(NetReferenceContainer* container, LPWCSTR signalName, NetVariantListContainer* parametersContainer) {
+Q_DECL_EXPORT uchar net_instance_activateSignal(NetReferenceContainer* container, const QChar* signalName, NetVariantListContainer* parametersContainer) {
     QList<NetValue*> liveInstances = NetValue::getAllLiveInstances(container->instance);
     if(liveInstances.length() == 0) {
         // Not alive in the QML world, so no signals to raise
         return false;
     }
 
-    QString signalNameString = QString::fromUtf16(signalName);
+    QString signalNameString(signalName);
 
     QSharedPointer<NetVariantList> parameters;
     if(parametersContainer != nullptr) {

--- a/src/native/QmlNet/QmlNet/types/NetSignalInfo.cpp
+++ b/src/native/QmlNet/QmlNet/types/NetSignalInfo.cpp
@@ -80,10 +80,10 @@ QString NetSignalInfo::getSlotSignature()
 
 extern "C" {
 
-Q_DECL_EXPORT NetSignalInfoContainer* signal_info_create(NetTypeInfoContainer* parentTypeContainer, LPWSTR name)
+Q_DECL_EXPORT NetSignalInfoContainer* signal_info_create(NetTypeInfoContainer* parentTypeContainer, QChar* name)
 {
     NetSignalInfoContainer* result = new NetSignalInfoContainer();
-    NetSignalInfo* instance = new NetSignalInfo(parentTypeContainer->netTypeInfo, QString::fromUtf16(static_cast<const char16_t*>(name)));
+    NetSignalInfo* instance = new NetSignalInfo(parentTypeContainer->netTypeInfo, QString(name));
     result->signal = QSharedPointer<NetSignalInfo>(instance);
     return result;
 }

--- a/src/native/QmlNet/QmlNet/types/NetTypeInfo.cpp
+++ b/src/native/QmlNet/QmlNet/types/NetTypeInfo.cpp
@@ -206,13 +206,9 @@ void NetTypeInfo::ensureLoaded() {
 
 extern "C" {
 
-static_assert (std::is_pointer<LPWSTR>::value, "Check fromUtf16 calls below.");
-static_assert (!std::is_pointer<std::remove_pointer<LPWSTR>::type>::value, "Check fromUtf16 calls below.");
-static_assert (sizeof(std::remove_pointer<LPWSTR>::type) == sizeof(ushort), "Check fromUtf16 calls below.");
-
-Q_DECL_EXPORT NetTypeInfoContainer* type_info_create(LPWSTR fullTypeName) {
+Q_DECL_EXPORT NetTypeInfoContainer* type_info_create(QChar* fullTypeName) {
     NetTypeInfoContainer* result = new NetTypeInfoContainer();
-    result->netTypeInfo = QSharedPointer<NetTypeInfo>(new NetTypeInfo(QString::fromUtf16(static_cast<const char16_t*>(fullTypeName))));
+    result->netTypeInfo = QSharedPointer<NetTypeInfo>(new NetTypeInfo(QString(fullTypeName)));
     return result;
 }
 
@@ -237,12 +233,12 @@ Q_DECL_EXPORT QmlNetStringContainer* type_info_getBaseType(NetTypeInfoContainer*
     return createString(result);
 }
 
-Q_DECL_EXPORT void type_info_setBaseType(NetTypeInfoContainer* netTypeInfo, LPWCSTR baseType)
+Q_DECL_EXPORT void type_info_setBaseType(NetTypeInfoContainer* netTypeInfo, const QChar* baseType)
 {
     if(baseType == nullptr) {
         netTypeInfo->netTypeInfo->setBaseType(QString());
     } else {
-        netTypeInfo->netTypeInfo->setBaseType(QString::fromUtf16(baseType));
+        netTypeInfo->netTypeInfo->setBaseType(QString(baseType));
     }
 }
 
@@ -251,8 +247,8 @@ Q_DECL_EXPORT QmlNetStringContainer* type_info_getClassName(NetTypeInfoContainer
     return createString(result);
 }
 
-Q_DECL_EXPORT void type_info_setClassName(NetTypeInfoContainer* netTypeInfo, LPWSTR className) {
-    netTypeInfo->netTypeInfo->setClassName(QString::fromUtf16(static_cast<const char16_t*>(className)));
+Q_DECL_EXPORT void type_info_setClassName(NetTypeInfoContainer* netTypeInfo, QChar* className) {
+    netTypeInfo->netTypeInfo->setClassName(QString(className));
 }
 
 Q_DECL_EXPORT uchar type_info_getIsArray(NetTypeInfoContainer* netTypeInfo)

--- a/src/native/QmlNet/QmlNet/types/NetTypeManager.cpp
+++ b/src/native/QmlNet/QmlNet/types/NetTypeManager.cpp
@@ -37,8 +37,8 @@ QSharedPointer<NetTypeInfo> NetTypeManager::getBaseType(QSharedPointer<NetTypeIn
 
 extern "C" {
 
-Q_DECL_EXPORT NetTypeInfoContainer* type_manager_getTypeInfo(LPWSTR fullTypeName) {
-    QSharedPointer<NetTypeInfo> typeInfo = NetTypeManager::getTypeInfo(QString::fromUtf16(static_cast<const char16_t*>(fullTypeName)));
+Q_DECL_EXPORT NetTypeInfoContainer* type_manager_getTypeInfo(QChar* fullTypeName) {
+    QSharedPointer<NetTypeInfo> typeInfo = NetTypeManager::getTypeInfo(QString(fullTypeName));
     if(typeInfo == nullptr) {
         return nullptr;
     }


### PR DESCRIPTION
Qt defines QChar as a class containing a ushort, which
should be consistently 16-bit across supported platforms.
this change uses QChar* instead of custom typedefs
to intepret LPWStr arguments passed to/from .NET.

See #190 