### PR TITLE
Fix Windows _UNICODE build

### DIFF
--- a/src/native/QmlNet/Hosting/CoreHost.cpp
+++ b/src/native/QmlNet/Hosting/CoreHost.cpp
@@ -22,7 +22,7 @@ static QString nativeModule;
 
 static void* getExportedFunction(const char* symbolName) {
 #ifdef _WIN32
-    HMODULE library = GetModuleHandle(nativeModule.isNull() || nativeModule.isEmpty() ? nullptr
+    HMODULE library = GetModuleHandleA(nativeModule.isNull() || nativeModule.isEmpty() ? nullptr
                                                                                      : nativeModule.toLocal8Bit());
     FARPROC symbol = GetProcAddress(library, symbolName);
     return (void*)symbol;


### PR DESCRIPTION
Use charset specific variant of GetModuleHandle without relying
on _UNICODE not being defined.

Fixes #197